### PR TITLE
Fix: wire temperature through to generation in LocalLLM

### DIFF
--- a/shared/llm.py
+++ b/shared/llm.py
@@ -40,11 +40,12 @@ class LocalLLM:
         """
         self.llm = Llama(
             model_path=model_path,
-            temperature=temperature,
             n_ctx=n_ctx,
             verbose=False,
+            seed=-1,
         )
         self.max_tokens = max_tokens
+        self.temperature = temperature
     
     def generate(self, prompt: str, temperature: float = None, stop: list[str] = None) -> str:
         """
@@ -64,8 +65,7 @@ class LocalLLM:
             "stop": stop if stop is not None else ["</s>", "\n\n", "User:", "Assistant:"],
         }
         
-        if temperature is not None:
-            kwargs["temperature"] = temperature
+        kwargs["temperature"] = temperature if temperature is not None else self.temperature
         
         response = self.llm(**kwargs)
         return response["choices"][0]["text"].strip()


### PR DESCRIPTION
Closes #6.

## What

Fixes a bug where the `temperature` parameter on `LocalLLM` is silently ignored at generation time. Also addresses a related reproducibility issue where identical responses repeat across runs because no seed is passed.

## Why

`llama-cpp-python` applies `temperature` at sampling time (per-call), not at model load. The current code passes `temperature` to the `Llama(...)` constructor, where it has no effect on subsequent `__call__` invocations. As a result, readers following Lesson 01 Exercise 2 ("Change the `temperature` in `shared/llm.py`") see no change when they edit the default, which contradicts the lesson text.

## Changes

Four edits in `shared/llm.py`: (1) store `self.temperature = temperature` in `LocalLLM.__init__`; (2) in `generate()`, default `kwargs["temperature"]` to `self.temperature` when no per-call override is supplied; (3) remove the now-unused `temperature=temperature` kwarg from the `Llama(...)` call; (4) add `seed=-1` to the `Llama(...)` call so each model load uses a fresh random seed.

## Testing

Ran `lesson_01_basic_chat()` twice with `temperature=0.0` (near-identical output across runs, as expected) and twice with `temperature=1.5` (clearly different output each run). Previously both temperatures produced byte-identical output across runs regardless of the value set in `__init__`.