### PR TITLE
docs(lesson-06): fix relative image path

### DIFF
--- a/lessons/06_agent_loop.md
+++ b/lessons/06_agent_loop.md
@@ -173,7 +173,7 @@ Input -> Step 1 -> Step 2 -> Step 3 -> Done
 ```
 Multiple steps in sequence, each deciding what to do next.
 
-![Agent Loop Flow](diagrams/lesson-06-agent-loop.png)
+![Agent Loop Flow](../diagrams/lesson-06-agent-loop.png)
 
 ## Key Insights
 

--- a/lessons/07_memory.md
+++ b/lessons/07_memory.md
@@ -132,7 +132,7 @@ if response2 and "reply" in response2:
 print(f"Memory contents: {agent.memory.get_all()}")
 ```
 
-![Memory System](diagrams/lesson-07-memory.png)
+![Memory System](../diagrams/lesson-07-memory.png)
 
 ## Compare to Lesson 06
 

--- a/lessons/08_planning.md
+++ b/lessons/08_planning.md
@@ -175,7 +175,7 @@ Plan -> Execute each step -> Results
 ```
 Generates and executes a sequence of steps.
 
-![Planning Flow](diagrams/lesson-08-planning.png)
+![Planning Flow](../diagrams/lesson-08-planning.png)
 
 ## Key Insights
 

--- a/lessons/10_atom_of_thought.md
+++ b/lessons/10_atom_of_thought.md
@@ -161,7 +161,7 @@ if graph:
     print(f"Execution results: {results}")
 ```
 
-![Atom of Thought Graph](diagrams/lesson-10-atom-of-thoght.png)
+![Atom of Thought Graph](../diagrams/lesson-10-atom-of-thoght.png)
 
 ## Compare to Lesson 09
 


### PR DESCRIPTION
adjust the image source path to correctly reference the shared diagrams directory

before:
<img width="856" height="268" alt="image" src="https://github.com/user-attachments/assets/7a88857a-adaf-4aba-a3d9-a6a4b1f7e86d" />

after:
<img width="747" height="504" alt="image" src="https://github.com/user-attachments/assets/367aa6a3-97f0-49ef-9f8f-45cb3cdd7aab" />
